### PR TITLE
fix: Improved distances_ and height documentation.

### DIFF
--- a/.devel/sphinx/rapi/gclust.md
+++ b/.devel/sphinx/rapi/gclust.md
@@ -92,7 +92,7 @@ If `d` is a numeric matrix or an object of class `dist`, [`mst()`](mst.md) will 
 
 Given an minimum spanning tree, the algorithm runs in $O(n \sqrt{n})$ time. Therefore, if you want to test different `gini_threshold`s, (or `k`s), it is best to explicitly compute the MST first.
 
-According to the algorithm\'s original definition, the resulting partition tree (dendrogram) might violate the ultrametricity property (merges might occur at levels that are not increasing w.r.t. a between-cluster distance). Departures from ultrametricity are corrected by applying `height = rev(cummin(rev(height)))`.
+According to the algorithm\'s original definition, the resulting partition tree (dendrogram) might violate the ultrametricity property (merges might occur at levels that are not increasing w.r.t. a between-cluster distance). `gclust()` automatically corrects departures from ultrametricity by applying `height = rev(cummin(rev(height)))`.
 
 ## Value
 

--- a/R/gclust.R
+++ b/R/gclust.R
@@ -85,8 +85,8 @@
 #' the resulting partition tree (dendrogram) might violate
 #' the ultrametricity property (merges might occur at levels that
 #' are not increasing w.r.t. a between-cluster distance).
-#' Departures from ultrametricity are corrected by applying
-#' \code{height = rev(cummin(rev(height)))}.
+#' \code{gclust()} automatically corrects departures from
+#' ultrametricity by applying \code{height = rev(cummin(rev(height)))}.
 #'
 #'
 #' @param d a numeric matrix (or an object coercible to one,

--- a/genieclust/genie.py
+++ b/genieclust/genie.py
@@ -793,10 +793,11 @@ class Genie(GenieBase):
         the distance between two clusters merged in each iteration,
         see the description of ``Z[:,2]`` in `scipy.cluster.hierarchy.linkage`.
 
-        As the original Genie algorithm does not guarantee that that distances
-        are ordered increasingly (there are other hierarchical
-        clustering linkages that violate the ultrametricity property as well),
-        these are corrected by applying
+        As the original Genie algorithm does not guarantee that distances
+        are ordered increasingly (there are other hierarchical clustering
+        linkages that violate the ultrametricity property as well), Genie
+        automatically applies the following correction:
+
         ``distances_ = genieclust.tools.cummin(distances_[::-1])[::-1]``.
 
     counts_ : None or ndarray


### PR DESCRIPTION
Made it more clear in the documentation that Genie automatically applies corrections to guarantee ultrametricity.

This addresses issue gagolews/genieclust#87.